### PR TITLE
[Bug Fix] PlayerScreen Scroll Issue

### DIFF
--- a/client/components/PlayerView/PlayerScreen.styles.tsx
+++ b/client/components/PlayerView/PlayerScreen.styles.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 
 export const styles = StyleSheet.create({
   playerList: {

--- a/client/components/PlayerView/PlayerScreen.styles.tsx
+++ b/client/components/PlayerView/PlayerScreen.styles.tsx
@@ -1,10 +1,8 @@
-import { StyleSheet } from "react-native";
+import { Dimensions, StyleSheet } from "react-native";
 
 export const styles = StyleSheet.create({
   playerList: {
-    alignItems: "center",
     justifyContent: "center",
-    paddingTop: 10,
     //TODO: This padding bottom is problematic. Find a better way!!
     paddingBottom: 120
   }


### PR DESCRIPTION
Fixed styling on PlayerScreen that caused the ability to scroll player list in all directions (found on iPhone XS iOS version 13.1.3) and fixed a margin on top (may be reverted if other mobile views don't align)

![ezgif-6-a893a22701d2](https://user-images.githubusercontent.com/24361520/75650100-d8347900-5c09-11ea-808f-e6301e10ce7f.gif)